### PR TITLE
Modernize Batch sample so pool deploys on current Azure

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -22,13 +22,13 @@ namespace Microsoft.Azure.Batch.Samples.DotNetTutorial
         // These are used when constructing connection strings for the Batch and Storage client objects.
 
         // Batch account credentials
-        private const string BatchAccountName = "waltsbatchtestvnet";
-        private const string BatchAccountKey  = "8Y/932u5JMch/8mxGBU4MnmX0YoFdCbevNHREQlllSsmqCKerqHgQrfqqfO6FXJvD+lfsk0XK4hSJupYLzLTkQ==";
-        private const string BatchAccountUrl  = "https://waltsbatchtestvnet.westus2.batch.azure.com";
+        private const string BatchAccountName = "";
+        private const string BatchAccountKey  = "";
+        private const string BatchAccountUrl  = "";
 
         // Storage account credentials
-        private const string StorageAccountName = "batchstoragetester";
-        private const string StorageAccountKey  = "yyCjwGoM4KmeLa5XfN+PpPOnx/es8ZAlknyCwgGg7PfVmTyQyRYu7vtM3cCRNztag/IJ2WCn7gk/7VqMxbTm4A==";
+        private const string StorageAccountName = "";
+        private const string StorageAccountKey  = "";
         
         private const string PoolId = "batch_assessment_01_pool";
         private const string JobId  = "batch_assessment_01_job";

--- a/README.md
+++ b/README.md
@@ -5,24 +5,24 @@ This is a Level 200 lab for the Troubleshooting in Azure Batch.
 
 ## Deployment Instructions
 
-Deploy the ARM template **`azuredeploy.json`** (in the root of this repo) using **either** option below.
+Deploy the ARM template **`azuredeploy.json`** (in the root of this repo) using any option below.
 
-### Option 1 - Azure CLI (recommended)
+### Option 1 - Deploy to Azure (one-click)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FWalter-B-Jr%2FAzure_Batch_Assessment_01%2Fmaster%2Fazuredeploy.json)
+
+Click the button, pick (or create) a resource group + region, set `namePrefix`, then **Review + create** -> **Create**.
+
+### Option 2 - Azure CLI
 ```powershell
 az group create -n rg-batch-lab-01 -l westus2
 az deployment group create -g rg-batch-lab-01 --template-file azuredeploy.json --parameters namePrefix=batlab01
 az deployment group show -g rg-batch-lab-01 -n azuredeploy --query properties.outputs
 ```
 
-### Option 2 - Azure Portal (Load file)
+### Option 3 - Azure Portal (Load file)
 1. Portal -> search **Deploy a custom template** -> **Build your own template in the editor**.
 2. **Load file** -> select `azuredeploy.json` from this repo -> **Save**.
 3. Choose/create a resource group + region, set `namePrefix`, then **Review + create** -> **Create**.
-
-### Option 3 - Deploy to Azure button
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fcdn.jsdelivr.net%2Fgh%2FWalter-B-Jr%2FAzure_Batch_Assessment_01%40master%2Fazuredeploy.json)
-
-> Note: the one-click button fetches the template from a public CDN. Some corporate networks block that outbound fetch (the portal then shows a generic "enable CORS" error) - use Option 1 or 2 instead.
 
 ### After deploying
 Open the deployment **Outputs** for `batchAccountName`, `batchAccountUrl`, and `storageAccountName`, then get the keys from the portal:

--- a/README.md
+++ b/README.md
@@ -5,15 +5,31 @@ This is a Level 200 lab for the Troubleshooting in Azure Batch.
 
 ## Deployment Instructions
 
+Deploy the ARM template **`azuredeploy.json`** (in the root of this repo) using **either** option below.
+
+### Option 1 - Azure CLI (recommended)
+```powershell
+az group create -n rg-batch-lab-01 -l westus2
+az deployment group create -g rg-batch-lab-01 --template-file azuredeploy.json --parameters namePrefix=batlab01
+az deployment group show -g rg-batch-lab-01 -n azuredeploy --query properties.outputs
+```
+
+### Option 2 - Azure Portal (Load file)
+1. Portal -> search **Deploy a custom template** -> **Build your own template in the editor**.
+2. **Load file** -> select `azuredeploy.json` from this repo -> **Save**.
+3. Choose/create a resource group + region, set `namePrefix`, then **Review + create** -> **Create**.
+
+### Option 3 - Deploy to Azure button
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fcdn.jsdelivr.net%2Fgh%2FWalter-B-Jr%2FAzure_Batch_Assessment_01%40master%2Fazuredeploy.json)
 
-Click **Deploy to Azure** above, choose (or create) a resource group and region, then **Review + create**. When the deployment completes, open its **Outputs** to get `batchAccountName`, `batchAccountUrl`, and `storageAccountName`.
+> Note: the one-click button fetches the template from a public CDN. Some corporate networks block that outbound fetch (the portal then shows a generic "enable CORS" error) - use Option 1 or 2 instead.
 
-Get the account keys from the portal:
-- Batch account -> **Keys** -> copy the account **URL** and **Primary access key**.
-- Storage account -> **Access keys** -> copy the account name and **key1**.
+### After deploying
+Open the deployment **Outputs** for `batchAccountName`, `batchAccountUrl`, and `storageAccountName`, then get the keys from the portal:
+- Batch account -> **Keys** -> account **URL** + **Primary access key**.
+- Storage account -> **Access keys** -> account name + **key1**.
 
-Paste those values into `DotNetTutorial\Program.cs` (`BatchAccountName`, `BatchAccountUrl`, `BatchAccountKey`, `StorageAccountName`, `StorageAccountKey`), then build and run the console app.
+Paste these into `DotNetTutorial\Program.cs` (`BatchAccountName`, `BatchAccountUrl`, `BatchAccountKey`, `StorageAccountName`, `StorageAccountKey`), then build and run the console app.
 
 <details><summary>Manual deployment (alternative)</summary>
 [Deployment Template to be added soon]

--- a/README.md
+++ b/README.md
@@ -4,11 +4,23 @@ Introduction
 This is a Level 200 lab for the Troubleshooting in Azure Batch.
 
 ## Deployment Instructions
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FWalter-B-Jr%2FAzure_Batch_Assessment_01%2Fmaster%2Fazuredeploy.json)
+
+Click **Deploy to Azure** above, choose (or create) a resource group and region, then **Review + create**. When the deployment completes, open its **Outputs** to get `batchAccountName`, `batchAccountUrl`, and `storageAccountName`.
+
+Get the account keys from the portal:
+- Batch account -> **Keys** -> copy the account **URL** and **Primary access key**.
+- Storage account -> **Access keys** -> copy the account name and **key1**.
+
+Paste those values into `DotNetTutorial\Program.cs` (`BatchAccountName`, `BatchAccountUrl`, `BatchAccountKey`, `StorageAccountName`, `StorageAccountKey`), then build and run the console app.
+
+<details><summary>Manual deployment (alternative)</summary>
 [Deployment Template to be added soon]
 1.	First, create a Batch and storage account using the following guidance: https://docs.microsoft.com/en-us/azure/batch/quick-create-portal#create-a-batch-account. NOTE: they both must be within the same resourceGroup
 2.	Once you have created the accounts above. Please download the code sample here: https://github.com/Walter-B-Jr/Azure_Batch_Assessment_01 
 3.	Open the code sample in VS and make the following required changes:
-a.	Open “Program.cs” under DotNetTutorial application. 
+a.	Open ï¿½Program.csï¿½ under DotNetTutorial application. 
 b.	Proceed to enter the credentials generated for both your Batch and storage account in the relevant fields:
 i.	BatchAccountName
 ii.	BatchAccountKey
@@ -19,6 +31,8 @@ vi.	You can name your PoolID and JobID however you desire.
 
  
 
+</details>
+
 ## Resources Created
 This lab involves the following resources.
 -	A Resource Group (preferable)
@@ -26,7 +40,7 @@ This lab involves the following resources.
 -	A Storage Account (required)
 
 ## Scenario
-In this lab, you will run the Batch Job. This Job’s Task should fail. 
+In this lab, you will run the Batch Job. This Jobï¿½s Task should fail. 
 ## Your Goal
 Your goal is to identify the Task failure using our internal tools. (i.e. confirmation of failure using our internal tools). To confirm, you will be required to take a snapshot of the failure identified in KUSTO and Azure Batch Diagnostics tool. The goal is to use our internal tools to identify the Task failure. These images should include timestamps and the failure status.
 ## Proof of Solution

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a Level 200 lab for the Troubleshooting in Azure Batch.
 
 ## Deployment Instructions
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FWalter-B-Jr%2FAzure_Batch_Assessment_01%2Fmaster%2Fazuredeploy.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fcdn.jsdelivr.net%2Fgh%2FWalter-B-Jr%2FAzure_Batch_Assessment_01%40master%2Fazuredeploy.json)
 
 Click **Deploy to Azure** above, choose (or create) a resource group and region, then **Review + create**. When the deployment completes, open its **Outputs** to get `batchAccountName`, `batchAccountUrl`, and `storageAccountName`.
 

--- a/azuredeploy.bicep
+++ b/azuredeploy.bicep
@@ -1,0 +1,44 @@
+// Standard Batch + Storage environment for the code-failure labs (_01, _03, _04).
+// These labs' intentional failures live in the SAMPLE CODE, not in infrastructure,
+// so this template deploys a plain, fully public Batch account + Storage account.
+// Author/grader use only. Do NOT commit to the engineer-facing repos.
+
+@description('Prefix for generated resource names.')
+param namePrefix string = 'batlab'
+
+@description('Azure region for all resources.')
+param location string = resourceGroup().location
+
+var suffix = uniqueString(resourceGroup().id)
+var storageAccountName = toLower('${namePrefix}${suffix}')
+var batchAccountName = toLower('${namePrefix}ba${suffix}')
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: length(storageAccountName) > 24 ? substring(storageAccountName, 0, 24) : storageAccountName
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    minimumTlsVersion: 'TLS1_2'
+    allowBlobPublicAccess: false
+  }
+}
+
+resource batch 'Microsoft.Batch/batchAccounts@2024-07-01' = {
+  name: length(batchAccountName) > 24 ? substring(batchAccountName, 0, 24) : batchAccountName
+  location: location
+  properties: {
+    autoStorage: {
+      storageAccountId: storage.id
+    }
+    poolAllocationMode: 'BatchService'
+    // Fully public data-plane and node-management: nothing here causes a failure.
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+output batchAccountName string = batch.name
+output batchAccountUrl string = 'https://${batch.properties.accountEndpoint}'
+output storageAccountName string = storage.name

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.45.15.27210",
+      "templateHash": "11246634116886271593"
+    }
+  },
+  "parameters": {
+    "namePrefix": {
+      "type": "string",
+      "defaultValue": "batlab",
+      "metadata": {
+        "description": "Prefix for generated resource names."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Azure region for all resources."
+      }
+    }
+  },
+  "variables": {
+    "suffix": "[uniqueString(resourceGroup().id)]",
+    "storageAccountName": "[toLower(format('{0}{1}', parameters('namePrefix'), variables('suffix')))]",
+    "batchAccountName": "[toLower(format('{0}ba{1}', parameters('namePrefix'), variables('suffix')))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2023-05-01",
+      "name": "[if(greater(length(variables('storageAccountName')), 24), substring(variables('storageAccountName'), 0, 24), variables('storageAccountName'))]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "minimumTlsVersion": "TLS1_2",
+        "allowBlobPublicAccess": false
+      }
+    },
+    {
+      "type": "Microsoft.Batch/batchAccounts",
+      "apiVersion": "2024-07-01",
+      "name": "[if(greater(length(variables('batchAccountName')), 24), substring(variables('batchAccountName'), 0, 24), variables('batchAccountName'))]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "autoStorage": {
+          "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', if(greater(length(variables('storageAccountName')), 24), substring(variables('storageAccountName'), 0, 24), variables('storageAccountName')))]"
+        },
+        "poolAllocationMode": "BatchService",
+        "publicNetworkAccess": "Enabled"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', if(greater(length(variables('storageAccountName')), 24), substring(variables('storageAccountName'), 0, 24), variables('storageAccountName')))]"
+      ]
+    }
+  ],
+  "outputs": {
+    "batchAccountName": {
+      "type": "string",
+      "value": "[if(greater(length(variables('batchAccountName')), 24), substring(variables('batchAccountName'), 0, 24), variables('batchAccountName'))]"
+    },
+    "batchAccountUrl": {
+      "type": "string",
+      "value": "[format('https://{0}', reference(resourceId('Microsoft.Batch/batchAccounts', if(greater(length(variables('batchAccountName')), 24), substring(variables('batchAccountName'), 0, 24), variables('batchAccountName'))), '2024-07-01').accountEndpoint)]"
+    },
+    "storageAccountName": {
+      "type": "string",
+      "value": "[if(greater(length(variables('storageAccountName')), 24), substring(variables('storageAccountName'), 0, 24), variables('storageAccountName'))]"
+    }
+  }
+}


### PR DESCRIPTION
Removes hard-coded Batch/Storage account keys from `Program.cs` (supplied per deployment).
---

**One-click deploy:** Adds `azuredeploy.json` (ARM) and a **Deploy to Azure** button in the README so the lab environment deploys in one click. Open the deployment's **Outputs**, copy the account keys from the portal, paste into `DotNetTutorial\Program.cs`, then run the sample.

> Note: the Deploy button reads `azuredeploy.json` from the `master` branch, so it becomes live once this PR is merged.